### PR TITLE
ActiveRecord 7.2 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,17 @@ All notable changes to this project will be documented in this file.
  
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
- 
+
+## [0.1.9] - 2026-04-28
+
+### Fixed
+
+- ActiveRecord 7.2 compatibility: adapter registration, `initialize` Hash config
+  path, `translate_exception`/`type_to_sql` keyword argument signatures,
+  `write_query?`, private `reconnect`, `@raw_connection` tracking, and
+  `quote_table_name` instance+class methods to satisfy AR 7.2's quoting
+  delegation chain
+
 ## [0.1.6] - 2022-06-10
 
 After @swistak35 identified issues with Rails 5.0 and 5.1 Issue#1, a new `def combine_bind_parameters` was added to the connection adapter to protect against bind variables being incorrectly organised, and a new `def unboundable?` was added to the visitor to protect against the non-existence of the routine in rails < 6

--- a/activerecord-advantage-adapter.gemspec
+++ b/activerecord-advantage-adapter.gemspec
@@ -1,7 +1,7 @@
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-pkg_version = "0.1.8"
+pkg_version = "0.1.9"
 
 Gem::Specification.new do |spec|
   spec.name = 'activerecord-advantage-adapter'
@@ -44,5 +44,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
 
   spec.add_runtime_dependency 'advantage', '~> 0.1', '>= 0.1.2'
-  # spec.add_runtime_dependency 'activerecord', '>= 3.2.0'
 end

--- a/activerecord-advantage-adapter.gemspec
+++ b/activerecord-advantage-adapter.gemspec
@@ -1,7 +1,7 @@
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-pkg_version = "0.1.9"
+pkg_version = "1.0.0"
 
 Gem::Specification.new do |spec|
   spec.name = 'activerecord-advantage-adapter'
@@ -39,9 +39,12 @@ Gem::Specification.new do |spec|
                    'activerecord-advantage-adapter.gemspec']
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = '>= 2.7'
+
   spec.add_development_dependency 'bundler', '~> 2.2.10'
   spec.add_development_dependency 'rake', '~> 12.3.3'
   spec.add_development_dependency 'rspec', '~> 3.0'
 
+  spec.add_runtime_dependency 'activerecord', '>= 7.0'
   spec.add_runtime_dependency 'advantage', '~> 0.1', '>= 0.1.2'
 end

--- a/lib/active_record/connection_adapters/advantage_adapter.rb
+++ b/lib/active_record/connection_adapters/advantage_adapter.rb
@@ -36,28 +36,19 @@ class ADS
   end
 end
 
+if ActiveRecord::ConnectionAdapters.respond_to?(:register)
+  ActiveRecord::ConnectionAdapters.register(
+    "advantage",
+    "ActiveRecord::ConnectionAdapters::AdvantageAdapter",
+    "active_record/connection_adapters/advantage_adapter"
+  )
+end
+
 module ActiveRecord
   class Base
-    DEFAULT_CONFIG = { :username => "adssys", :password => nil }
-    # Main connection function to Advantage
-    # Connection Adapter takes four parameters:
-    # * :database (required, no default). Corresponds to "Data Source=" in connection string
-    # * :username (optional, default to 'adssys'). Correspons to "User ID=" in connection string
-    # * :password (optional, deafult to '')
-    # * :options (optional, defaults to ''). Corresponds to any additional options in connection string
-
     def self.advantage_connection(config)
-      config = DEFAULT_CONFIG.merge(config)
-
-      raise ArgumentError, "No data source was given. Please add a :database option." unless config.has_key?(:database)
-
-      connection_string = "data source=#{config[:database]};User ID=#{config[:username]};"
-      connection_string += "Password=#{config[:password]};" unless config[:password].nil?
-      connection_string += "#{config[:options]};" unless config[:options].nil?
-      connection_string += "DateFormat=YYYY-MM-DD;"
-
+      connection_string = ConnectionAdapters::AdvantageAdapter.build_connection_string(config)
       db = ADS.instance.api.ads_new_connection()
-
       ConnectionAdapters::AdvantageAdapter.new(db, logger, connection_string)
     end
   end
@@ -115,12 +106,32 @@ module ActiveRecord
     end
 
     class AdvantageAdapter < AbstractAdapter
-      def initialize(connection, logger, connection_string = "") #:nodoc:
-        super(connection, logger)
+      DEFAULT_CONFIG = { username: "adssys", password: nil }
+
+      def self.build_connection_string(config)
+        config = DEFAULT_CONFIG.merge(config.symbolize_keys)
+        cs = "data source=#{config[:database]};User ID=#{config[:username]};"
+        cs += "Password=#{config[:password]};" unless config[:password].nil?
+        cs += "#{config[:options]};" unless config[:options].nil?
+        cs += "DateFormat=YYYY-MM-DD;"
+        cs
+      end
+
+      def initialize(config_or_deprecated_connection, deprecated_logger = nil, deprecated_connection_string = "") #:nodoc:
+        if config_or_deprecated_connection.is_a?(Hash)
+          super(config_or_deprecated_connection)
+          config = config_or_deprecated_connection.symbolize_keys
+          raise ArgumentError, "No data source was given. Please add a :database option." unless config.key?(:database)
+          @connection_string = self.class.build_connection_string(config)
+          @connection = ADS.instance.api.ads_new_connection()
+        else
+          super(config_or_deprecated_connection, deprecated_logger)
+          @connection = config_or_deprecated_connection
+          @connection_string = deprecated_connection_string
+        end
         @prepared_statements = false
         @auto_commit = true
         @affected_rows = 0
-        @connection_string = connection_string
         @visitor = Arel::Visitors::Advantage.new self
         connect!
       end
@@ -148,9 +159,12 @@ module ActiveRecord
         super
       end
 
-      def reconnect! #:nodoc:
-        disconnect!
-        connect!
+      def reconnect!(restore_transactions: false) #:nodoc:
+        super
+      end
+
+      def write_query?(sql) #:nodoc:
+        false
       end
 
       def supports_count_distinct? #:nodoc:
@@ -186,8 +200,23 @@ module ActiveRecord
         }
       end
 
-      # Applies quotations around column names in generated queries
+      # AR 7.2 routes instance quote_column_name/quote_table_name through
+      # self.class.* (ClassMethods). Define both instance and class forms so
+      # the delegation chain never hits AbstractAdapter::ClassMethods which
+      # raises NotImplementedError.
+      def self.quote_column_name(name)
+        %("#{name}")
+      end
+
+      def self.quote_table_name(name)
+        %("#{name}")
+      end
+
       def quote_column_name(name) #:nodoc:
+        %("#{name}")
+      end
+
+      def quote_table_name(name) #:nodoc:
         %("#{name}")
       end
 
@@ -200,24 +229,25 @@ module ActiveRecord
       end
 
       # Translate the exception if possible
-      def translate_exception(exception, message) #:nodoc:
+      # Accept both AR < 7.2 positional (message) and AR >= 7.2 keyword args
+      def translate_exception(exception, *positional, message: nil, sql: nil, binds: nil, **) #:nodoc:
+        message = message || positional.first
         return super unless exception.respond_to?(:errno)
 
         case exception.errno
         when 2121
           if exception.sql !~ /^SELECT/i
-            raise ActiveRecord::ActiveRecordError.new(message)
+            ActiveRecord::ActiveRecordError.new(message)
           else
             super
           end
         when 7076
-          raise InvalidForeignKey.new(message, exception)
+          InvalidForeignKey.new(message, exception)
         when 7057
-          raise RecordNotUnique.new(message, exception)
+          RecordNotUnique.new(message, exception)
         else
           super
         end
-        super
       end
 
       # The database update function.
@@ -274,8 +304,13 @@ module ActiveRecord
       end
 
       # Returns a query as an array of arrays
-      def select_rows(sql, name = nil)
-        exec_query(sql, name).rows
+      def select_rows(arel, name = nil, binds = [], **kwargs)
+        exec_query(arel, name, binds).rows
+      end
+
+      def internal_exec_query(sql, name = "SQL", binds = [], **_kwargs) #:nodoc:
+        cols, record = execute(sql, name)
+        ActiveRecord::Result.new(cols, record)
       end
 
       # Begin a transaction
@@ -301,17 +336,21 @@ module ActiveRecord
       end
 
       # Advantage does not support sizing of integers based on the sytax INTEGER(size).
-      def type_to_sql(type, limit = nil, precision = nil, scale = nil) #:nodoc:
+      # Accept both AR < 7.2 positional (limit, precision, scale) and AR >= 7.2 keyword args
+      def type_to_sql(type, *positional, limit: nil, precision: nil, scale: nil, **) #:nodoc:
+        limit     = limit     || positional[0]
+        precision = precision || positional[1]
+        scale     = scale     || positional[2]
         if native_database_types[type]
           if type == :integer
             'integer'
           elsif type == :string && !limit.nil?
             "varchar (#{limit})"
           else
-            super(type, limit, precision, scale)
+            super
           end
         else
-          super(type, limit, precision, scale)
+          super
         end
       end
 
@@ -434,7 +473,7 @@ SQL
 
       # Alter a column
       def change_column(table_name, column_name, type, options = {}) #:nodoc:
-        add_column_sql = "ALTER TABLE #{quote_table_name(table_name)} ALTER #{quote_column_name(column_name)} #{quote_column_name(column_name)} #{type_to_sql(type, type_options[:limit], type_options[:precision], type_options[:scale])}"
+        add_column_sql = "ALTER TABLE #{quote_table_name(table_name)} ALTER #{quote_column_name(column_name)} #{quote_column_name(column_name)} #{type_to_sql(type, limit: type_options[:limit], precision: type_options[:precision], scale: type_options[:scale])}"
         add_column_options!(add_column_sql, options)
         execute(add_column_sql)
       end
@@ -450,7 +489,7 @@ SQL
 
       # Rename a column
       def rename_column(table_name, column_name, new_column_name) #:nodoc:
-        execute "ALTER TABLE #{quote_table_name(table_name)} ALTER #{quote_column_name(column_name)} #{quote_column_name(new_column_name)} #{type_to_sql(type, type_options[:limit], type_options[:precision], type_options[:scale])}"
+        execute "ALTER TABLE #{quote_table_name(table_name)} ALTER #{quote_column_name(column_name)} #{quote_column_name(new_column_name)} #{type_to_sql(type, limit: type_options[:limit], precision: type_options[:precision], scale: type_options[:scale])}"
       end
 
       # Drop a column from a table
@@ -563,6 +602,14 @@ SQL
           error = ADS.instance.api.ads_error(@connection)
           raise ActiveRecord::ActiveRecordError.new("#{error}: Cannot Establish Connection")
         end
+        @raw_connection = @connection
+      end
+
+      # AR 7.2 requires private #reconnect; called by the public reconnect!
+      def reconnect #:nodoc:
+        ADS.instance.api.ads_disconnect(@connection)
+        @connection = ADS.instance.api.ads_new_connection()
+        connect!
       end
 
       # The database execution function


### PR DESCRIPTION
## Problem

ActiveRecord 7.2 introduced several breaking changes to the adapter contract that caused the adapter to fail completely on load and at query time.

## Root causes and fixes

### 1. Adapter registration
AR 7.2 requires adapters to call `ActiveRecord::ConnectionAdapters.register` at load time so the connection pool can resolve the adapter class by name. Without this the pool raises `ActiveRecord::AdapterNotFound`.

### 2. `initialize` signature
AR 7.2's pool instantiates adapters via `AdapterClass.new(config_hash)` instead of passing a raw connection object. Updated `initialize` to accept a Hash on the new path while keeping the legacy raw-connection path for backward compatibility.

### 3. Keyword argument signatures
`translate_exception` and `type_to_sql` both changed to keyword arguments in AR 7.2. Updated both signatures accordingly.

### 4. `write_query?`
AR 7.2's abstract adapter declares `write_query?` as abstract (raises `NotImplementedError`). Added an implementation returning `false`.

### 5. Private `reconnect` method
AR 7.2's public `reconnect!` delegates to a private `reconnect` method. Added the private method to disconnect and reconnect the ADS connection, and set `@raw_connection` inside `connect!` for AR 7.2's connection-state tracking.

### 6. Quoting methods (primary runtime failure)
AR 7.2 changed `AbstractAdapter`'s instance-level `quote_column_name` and `quote_table_name` to delegate to their class-method counterparts via `self.class.*`, with `AbstractAdapter::ClassMethods` raising `NotImplementedError` for both.

The adapter had an instance `quote_column_name` but **no `quote_table_name`** at all. So when the Arel visitor called `@connection.quote_table_name`, the call fell through:

```
@connection.quote_table_name(name)
  → Quoting#quote_table_name (instance) → self.class.quote_table_name
  → AbstractAdapter::ClassMethods#quote_table_name → quote_column_name (class)
  → AbstractAdapter::ClassMethods#quote_column_name → raise NotImplementedError
```

Fix: added both methods as instance methods **and** class methods so the delegation chain works regardless of which path AR 7.2 uses.
